### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name" : "License::Software",
+  "license" : "LGPL-3.0+",
   "source-url" : "https://github.com/kalkin/License-Software.git",
   "support" : {
     "source" : "https://github.com/kalkin/License-Software",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license