### PR TITLE
Sort .keys in tests

### DIFF
--- a/t/11-Apache2.t
+++ b/t/11-Apache2.t
@@ -14,7 +14,7 @@ is $license.copyright-note(), 'Copyright [2000-2016] Bahtiar `kalkin-` Gadimov',
 is $license.copyright, 'Copyright', "Copyright is just 'copyright'";
 is $license.works-name(), 'This program', "Default programm name should 'This program'";
 is $license.note(), 'Please see the file called LICENSE.';
-is $license.files.keys(), ['NOTICE', 'LICENSE'], 'The Apache license and NOTICE file';
+is $license.files().keys.sort, ['LICENSE', 'NOTICE'], 'The Apache license and NOTICE file';
 
 ok $license = License::Software::get('apache').new("FooBar", "Bahtiar `kalkin-` Gadimov" =>  2000..2016);
 is $license.holders.elems, 1, 'Should have 1 holder';

--- a/t/12-LGPLv3.t
+++ b/t/12-LGPLv3.t
@@ -9,7 +9,7 @@ ok my License::Software::Abstract $license = License::Software::get('lgplv3').ne
 is $license.short-name(), 'LGPLv3', 'Short license name';
 is $license.name(), 'The GNU Lesser General Public License, Version 3, 29 June 2007', 'Full license name';
 is $license.aliases(), ['LGPLv3', 'LGPL3', 'LGPL', $license.spdx], 'License Aliases';
-is $license.files().keys, ['COPYING.LESSER', 'COPYING'], 'License files';
+is $license.files().keys.sort, ['COPYING', 'COPYING.LESSER'], 'License files';
 
 my $gpl = License::Software::get('gplv3').new("Bahtiar kalkin- Gadimov");
 is $license.files()<COPYING>, $gpl.full-text(), 'Fill GPL3 Text';

--- a/t/14-Artistic2.t
+++ b/t/14-Artistic2.t
@@ -8,7 +8,7 @@ ok my License::Software::Abstract $license = License::Software::get(<artistic>).
 is $license.short-name(), 'Artistic2', 'Short license name';
 is $license.name(), 'The Artistic License 2.0 (GPL Compatible)', 'Full license name';
 is $license.aliases(), ['Artistic', 'Artistic2', $license.spdx], 'License Aliases';
-is $license.files().keys, ['LICENSE'], 'License file';
+is $license.files().keys.sort, ['LICENSE'], 'License file';
 is $license.header(), '', 'Artistic License does not need a header for each file';
 is $license.files()<LICENSE>, $license.full-text(), 'Full Artistic2 Text';
 is $license.url(), <http://www.perlfoundation.org/artistic_license_2_0>, 'The Artistic2 url';

--- a/t/20-spdx.t
+++ b/t/20-spdx.t
@@ -3,7 +3,7 @@ use Test;
 use License::Software;
 
 my $pair = "Bahtiar `kalkin-` Gadimov" => 2000..2016;
-my @license-names = License::Software::.keys.grep(* !~~ (<Year>|<Holder>|<Abstract>|/\&/));
+my @license-names = License::Software::.keys.sort.grep(* !~~ (<Year>|<Holder>|<Abstract>|/\&/));
 my @spdx = [ <Glide>, <Abstyles>, <AFL-1.1>, <AFL-1.2>, <AFL-2.0>, <AFL-2.1>,
             <AFL-3.0>, <AMPAS>, <APL-1.0>, <Adobe-Glyph>, <APAFML>,
             <Adobe-2006>, <AGPL-1.0>, <Afmparse>, <Aladdin>, <ADSL>, <AMDPLPA>,


### PR DESCRIPTION
Hash keys can be returned in any order, which is why these tests were
failing sometimes. Quickfixed by sorting the keys.